### PR TITLE
Add missing ERB require

### DIFF
--- a/lib/graphql_playground.rb
+++ b/lib/graphql_playground.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+require 'erb'
 
 class GraphQLPlayground
   CDN_URL = '//cdn.jsdelivr.net/npm'
 
-  # Initialize the middleware 
+  # Initialize the middleware
   #
   # @param string cdn_url The CDN url for graphql playground (defaults to the official release)
   # @param string version The version of the graphql playground to use (defaults to latest)


### PR DESCRIPTION
Hey @betaflag 👋 I'm using your graphql server with playground, awesome job and thanks a lot! 

I've noticed that if we're using puma web server then we're going to receive the following error on playground load:
```
Puma caught this error: uninitialized constant GraphQLPlayground::ERB (NameError)
/bundle/ruby/2.7.0/gems/graphql_playground-0.0.1/lib/graphql_playground.rb:24:in `call'
/bundle/ruby/2.7.0/gems/rack-2.2.0/lib/rack/urlmap.rb:74:in `block in call'
/bundle/ruby/2.7.0/gems/rack-2.2.0/lib/rack/urlmap.rb:58:in `each'
/bundle/ruby/2.7.0/gems/rack-2.2.0/lib/rack/urlmap.rb:58:in `call'
/bundle/ruby/2.7.0/gems/puma-4.3.1/lib/puma/configuration.rb:228:in `call'
/bundle/ruby/2.7.0/gems/puma-4.3.1/lib/puma/server.rb:681:in `handle_request'
/bundle/ruby/2.7.0/gems/puma-4.3.1/lib/puma/server.rb:472:in `process_client'
/bundle/ruby/2.7.0/gems/puma-4.3.1/lib/puma/server.rb:328:in `block in run'
/bundle/ruby/2.7.0/gems/puma-4.3.1/lib/puma/thread_pool.rb:134:in `block in spawn_thread'
```

It seems that adding `require 'erb'` to the top of the file is fixing this problem.